### PR TITLE
Treating the case where the Lattice is not full-rank

### DIFF
--- a/liblll.py
+++ b/liblll.py
@@ -207,9 +207,9 @@ def best_vect_knapsack(n):
 
 # gram schmidt algorithm
 def gram_schmidt(g, m, mu, B):
-    row = len(m)
+    col = len(g[0])
 
-    for i in range(row):
+    for i in range(col):
         # bi* = bi
         b_i = get_vector(g, i)
         b_i_star = b_i
@@ -300,7 +300,7 @@ def lll_reduction(n, lc=Fraction(3, 4)):
                 mu[k-1][j] = mu[k][j]
                 mu[k][j] = save
 
-            for i in range(k+1, row):
+            for i in range(k+1, col):
                 save = mu[i][k-1]
                 mu[i][k-1] = mu[k][k-1]*mu[i][k-1] + mu[i][k] - u*mu[i][k]*mu[k][k-1]
                 mu[i][k] = save - u*mu[i][k]
@@ -313,7 +313,7 @@ def lll_reduction(n, lc=Fraction(3, 4)):
             for l in range(k-2, -1, -1):
                 reduce(g, mu, k, l)
 
-            if k == row-1:
+            if k == col-1:
                 return g
 
             k = k + 1
@@ -329,12 +329,12 @@ def islll(n, lc=Fraction(3, 4)):
 
     gram_schmidt(n, m, mu, B)
 
-    for i in range(row):
+    for i in range(col):
         for j in range(i):
             if math.fabs(mu[i][j]) > Fraction(1, 2):
                 return False
 
-    for k in range(1, row):
+    for k in range(1, col):
         if B[k] < (lc - mu[k][k-1]*mu[k][k-1])*B[k-1]:
             return False
     return True

--- a/liblll.py
+++ b/liblll.py
@@ -256,9 +256,9 @@ def lll_reduction(n, lc=Fraction(3, 4)):
     col = len(n[0])
 
     m = [ [Fraction(0) for j in range(col) ] for i in range(row)]
-    mu = [ [Fraction(0) for j in range(col) ] for i in range(row)]
+    mu = [ [Fraction(0) for j in range(col) ] for i in range(col)]
     g = [ [n[i][j] for j in range(col) ] for i in range(row)]
-    B = [ Fraction(0) for j in range(row) ]
+    B = [ Fraction(0) for j in range(col) ]
 
     gram_schmidt(g, m, mu, B)
 
@@ -324,8 +324,8 @@ def islll(n, lc=Fraction(3, 4)):
     col = len(n[0])
 
     m = [ [Fraction(0) for j in range(col) ] for i in range(row)]
-    mu = [ [Fraction(0) for j in range(col) ] for i in range(row)]
-    B = [ Fraction(0) for j in range(row) ]
+    mu = [ [Fraction(0) for j in range(col) ] for i in range(col)]
+    B = [ Fraction(0) for j in range(col) ]
 
     gram_schmidt(n, m, mu, B)
 

--- a/liblll.py
+++ b/liblll.py
@@ -63,38 +63,23 @@ def print_vector(v):
 
 # get vector j in the matrix n
 def get_vector(n, j):
-    res = []
-    for i in range(len(n)):
-        res.append(n[i][j])
-    return res
+    return [ n[i][j] for i in range(len(n))]
 
 # vector substraction 
 def vector_add(a, b):
-    res = []
-    for i in range(len(a)):
-        res.append(a[i] + b[i])
-    return res
+    return [ a[i] + b[i] for i in range(len(a)) ]
 
 # vector substraction 
 def vector_sub(a, b):
-    res = []
-    for i in range(len(a)):
-        res.append(a[i] - b[i])
-    return res
+    return [ a[i] - b[i] for i in range(len(a)) ]
 
 # vector multiplication with a constant
 def vector_mult_const(v, k):
-    res = []
-    for i in range(len(v)):
-        res.append(v[i]*k)
-    return res
+    return [ v[i]*k for i in range(len(v)) ]
 
-# set vector j in the matrix n with vector v
+# set the k-th column of matrix n to the vector v
 def set_matrix_vector(n, k, v):
     row = len(n)
-    col = len(n[0])
- 
-    # edit the good column
     for i in range(row):
         n[i][k] = v[i]
         
@@ -233,7 +218,6 @@ def gram_schmidt(g, m, mu, B):
 # reduce
 def reduce(g, mu, k, l):
     row = len(g)
-    col = len(g[0])
 
     if math.fabs(mu[k][l]) > Fraction(1, 2):
         r = round(mu[k][l])

--- a/unit-tests.py
+++ b/unit-tests.py
@@ -135,6 +135,8 @@ class LLLTestCase(unittest.TestCase):
         self.second_sum = 68924182376697138
         self.best_vect_first_sum = [0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0]
         self.best_vect_second_sum = [0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1]
+        self.not_full_rank = [ [ 0, 17, 1], [10, 100, 80], [-9, 11, 76], [110, 50, 60]]
+        self.not_full_rank_reduced = [ [ -16, 0, 17], [-20, 10, 90], [65, -9, 20], [10, 110, -60]]
 
     def test_gram_schmidt(self):
         mu = [[Fraction(0), Fraction(0)], [Fraction(0), Fraction(0)]]
@@ -188,6 +190,14 @@ class LLLTestCase(unittest.TestCase):
         self.assertEqual(1, islll(second_mat_reduced)) 
         res = best_vect_knapsack(second_mat_reduced)
         self.assertEqual(self.best_vect_second_sum, res) 
+
+    def test_lll_reduction_not_full_rank(self):
+        basis = create_matrix(self.not_full_rank)
+        expected_reduced_basis = create_matrix(self.not_full_rank_reduced)
+        reduced_basis = lll_reduction(basis)
+        self.assertEqual(expected_reduced_basis, reduced_basis) 
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Full-rank lattices have squares matrices representing their basis and the code of this project was working in this case, but, even so, there were some confusions about the variables row and col (namely, the number of rows and the number of columns of the basis).

Now, it is also working for lattices that have not square matrices as their basis, it means, their basis have n vector and each vector belongs to Z^m, with n < m.

As a simple example, consider the following python script:

--------------------------------------------------------------------
```
from liblll import *

B = [ [ 0, 17, 1], [10, 100, 80], [-9, 11, 76], [110, 50, 60]]
B = create_matrix(B) 
print "\nLattice basis:"
print_mat(B)

print "\n--- reducing...\n"

R = lll_reduction(B)
print_mat(R)
print islll(R)
```
--------------------------------------------------------------------

It creates a 4x3 matrix representing a basis that have the following vectors:
(0,    10,    -9,   110)
(17,  100,  11,  50)
(1,   80,    76,   60)

and runs the lll_reduction.

It raises the following error:
  
![print_erro_lll](https://cloud.githubusercontent.com/assets/3042726/22601226/1edf56d6-ea25-11e6-8031-1f950e3ac32e.png)

Furthermore, I did some small editions cleaning up the code and I create a very simple unit-test.